### PR TITLE
fix: Login component mount error

### DIFF
--- a/webpack/publish.config.js
+++ b/webpack/publish.config.js
@@ -12,8 +12,7 @@ var HtmlWebpackExternalsPlugin = require('html-webpack-externals-plugin');
 var settings = require('@back4app/back4app-settings');
 
 configuration.entry = {
-  dashboard: './dashboard/index.js',
-  login: './login/index.js'
+  dashboard: './dashboard/index.js'
 };
 configuration.output.path = path.resolve('./Parse-Dashboard/public/bundles');
 configuration.output.filename = "[name].[chunkhash].js";


### PR DESCRIPTION
Fixes the following error after loading the parse-dashboard:
```
Uncaught Error: Minified React error #37; visit http://facebook.github.io/react/docs/error-decoder.html?invariant=37 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at r (login.4fe931013428dbcb6960.js:1)
    at Object._renderNewRootComponent (login.4fe931013428dbcb6960.js:20)
    at Object._renderSubtreeIntoContainer (login.4fe931013428dbcb6960.js:20)
    at Object.render (login.4fe931013428dbcb6960.js:20)
    at Object.<anonymous> (login.4fe931013428dbcb6960.js:20)
    at t (login.4fe931013428dbcb6960.js:1)
    at login.4fe931013428dbcb6960.js:1
    at login.4fe931013428dbcb6960.js:1
```