### PR TITLE
showing '(auto)' for auto-generated fields 

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -322,7 +322,7 @@ class BrowserCell extends Component {
               this.setState({ showTooltip: false });
             }, 2000);
           }}>
-          {content}
+          {row < 0 ? '(auto)' : content}
         </span>
       </Tooltip> :
         <span


### PR DESCRIPTION
Showing 'auto' for auto-generated fields while creating new row or editing cloned rows.
Bascially for readOnly fields while adding new row(or cloning).

- For Custom Classes (general case)
![Screenshot from 2021-04-28 23-45-52](https://user-images.githubusercontent.com/44117648/116454542-ba01f180-a87d-11eb-99da-df74de258af7.png)

- For Session class
![Screenshot from 2021-04-28 23-57-53](https://user-images.githubusercontent.com/44117648/116454547-bb331e80-a87d-11eb-8140-ee732fbbb2c5.png)
