### PR TITLE
Add option to create a field after creating a class

### DIFF
--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -40,6 +40,9 @@ let Modal = (({
   customFooter,
   textModal = false,
   width,
+  continueText,
+  onContinue,
+  showContinue,
   buttonsInCenter = React.Children.count(children) === 0,
 }) => {
   if (children) {
@@ -64,6 +67,15 @@ let Modal = (({
         disabled={!!disabled}
         onClick={onConfirm}
         progress={progress} />
+      {
+        showContinue === true ?
+        <Button
+          primary={true}
+          value={continueText}
+          color={buttonColors[type]}
+          disabled={!!disabled}
+          onClick={onContinue}
+          progress={progress} />: null}
     </div>
   );
 

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -229,7 +229,7 @@ export default class AddColumnDialog extends React.Component {
         confirmText='Add column'
         cancelText={'Never mind, don\u2019t.'}
         onCancel={this.props.onCancel}
-        continueText={'Create column & add another'}
+        continueText={'Add column & continue'}
         showContinue={true}
         onContinue={() => this.props.onContinue(this.state)}
         onConfirm={() => {

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -229,6 +229,9 @@ export default class AddColumnDialog extends React.Component {
         confirmText='Add column'
         cancelText={'Never mind, don\u2019t.'}
         onCancel={this.props.onCancel}
+        continueText={'Create column & add another'}
+        showContinue={true}
+        onContinue={() => this.props.onContinue(this.state)}
         onConfirm={() => {
           this.props.onConfirm(this.state);
         }}>

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -673,7 +673,10 @@ class Browser extends DashboardView {
       required,
       defaultValue
     };
-    this.newColumn(payload);
+    this.newColumn(payload).finally(() => {
+      this.setState({ showAddColumnDialog: false, keepAddingCols: false });
+      this.setState({ showAddColumnDialog: true, keepAddingCols: true });
+    });
   }
 
   addRow() {

--- a/src/dashboard/Data/Browser/CreateClassDialog.react.js
+++ b/src/dashboard/Data/Browser/CreateClassDialog.react.js
@@ -13,6 +13,7 @@ import Option             from 'components/Dropdown/Option.react';
 import React              from 'react';
 import { SpecialClasses } from 'lib/Constants';
 import TextInput          from 'components/TextInput/TextInput.react';
+import history                           from 'dashboard/history';
 
 function validClassName(name) {
   return !!name.match(/^[a-zA-Z][_a-zA-Z0-9]*$/);
@@ -68,7 +69,16 @@ export default class CreateClassDialog extends React.Component {
         disabled={!this.valid()}
         confirmText='Create class'
         cancelText={'Cancel'}
+        continueText={'Create class & add columns'}
         onCancel={this.props.onCancel}
+        showContinue={true}
+        onContinue={async () => {
+          let type = this.state.type;
+          let className = type === 'Custom' ? this.state.name : '_' + type;
+          await this.props.onConfirm(className);
+          history.push(`/apps/${this.props.currentAppSlug}/browser/${className}`);
+          this.props.onAddColumn();
+        }}
         onConfirm={() => {
           let type = this.state.type;
           let className = type === 'Custom' ? this.state.name : '_' + type;

--- a/src/dashboard/Data/Browser/CreateClassDialog.react.js
+++ b/src/dashboard/Data/Browser/CreateClassDialog.react.js
@@ -13,7 +13,7 @@ import Option             from 'components/Dropdown/Option.react';
 import React              from 'react';
 import { SpecialClasses } from 'lib/Constants';
 import TextInput          from 'components/TextInput/TextInput.react';
-import history                           from 'dashboard/history';
+import history            from 'dashboard/history';
 
 function validClassName(name) {
   return !!name.match(/^[a-zA-Z][_a-zA-Z0-9]*$/);


### PR DESCRIPTION
To tie the flows, the dialogs to create a Class and to add a column have been connected via continue buttons.
Upon clicking the continue buttons, the flow continues.
This is a PR for the following issue:- issue link

<img width="832" alt="121908097-1c3b8680-cd46-11eb-8796-58ca55d81cf8" src="https://user-images.githubusercontent.com/23558802/122365919-89ccfa00-cf74-11eb-9692-a0eaf9b3d60c.png">
<img width="832" alt="121908125-1fcf0d80-cd46-11eb-836c-996aa099f6a6" src="https://user-images.githubusercontent.com/23558802/122365975-96515280-cf74-11eb-91fd-ff734e7b666e.png">
<img width="832" alt="121908132-21003a80-cd46-11eb-9902-1f15d9541d1b" src="https://user-images.githubusercontent.com/23558802/122366080-af5a0380-cf74-11eb-8b84-129095ba0623.png">
<img width="982" alt="121908142-23629480-cd46-11eb-9cf0-f15c3b851e08" src="https://user-images.githubusercontent.com/23558802/122366198-c567c400-cf74-11eb-8936-e5d5b98bd27a.png">
