### PR TITLE
Parse Dashboard Crash: When user creates a new class with the reserved classes names.

### DIFF
--- a/src/dashboard/Data/Browser/CreateClassDialog.react.js
+++ b/src/dashboard/Data/Browser/CreateClassDialog.react.js
@@ -45,6 +45,9 @@ class CreateClassDialog extends React.Component {
     if (this.props.currentClasses.indexOf(this.state.name) > -1) {
       return false;
     }
+    if (SpecialClasses.includes(`_${this.state.name}`)) {
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188357250