### PR TITLE
Remove used packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "crypto-js": "4.2.0",
     "csurf": "1.11.0",
     "csvtojson": "2.0.10",
-    "eslint-linter-browserify": "9.14.0",
     "express": "4.19.2",
     "file-loader": "6.2.0",
     "globals": "15.12.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "js-cookie": "3.0.5",
     "jstree": "3.3.16",
     "lottie-react": "2.4.0",
-    "moment": "2.29.4",
     "otpauth": "8.0.3",
     "package-json": "7.0.0",
     "parse": "git+https://github.com/back4app/Parse-SDK-JS.git#back4app-upstream-3.4.2",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "react-player": "2.13.0",
     "react-popper-tooltip": "4.4.2",
     "react-router-dom": "6.2.1",
-    "react-syntax-highlighter": "15.5.0",
     "react-tabs": "4.0.0",
     "regenerator-runtime": "0.13.11",
     "semver": "7.5.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "lottie-react": "2.4.0",
     "otpauth": "8.0.3",
     "package-json": "7.0.0",
+    "papaparse": "5.5.2",
     "parse": "git+https://github.com/back4app/Parse-SDK-JS.git#back4app-upstream-3.4.2",
     "passport": "0.5.3",
     "passport-local": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@uiw/react-codemirror": "4.23.6",
     "axios": "1.5.1",
     "axios-rate-limit": "1.3.0",
-    "base64-async": "2.1.3",
     "bcryptjs": "2.3.0",
     "body-parser": "1.20.0",
     "commander": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -224,5 +224,10 @@
       "eslint --fix --cache",
       "git add"
     ]
-  }
+  },
+  "sideEffects": [
+    "*.css",
+    "*.scss",
+    "./src/components/B4ACodeTree/B4ACodeTree.react.js"
+  ]
 }

--- a/src/components/B4ACloudCodeView/B4ACloudCodeView.react.js
+++ b/src/components/B4ACloudCodeView/B4ACloudCodeView.react.js
@@ -7,7 +7,7 @@ import React from 'react';
 import B4aCodeEditor from '../CodeEditor/B4aCodeEditor.react';
 import { getExtension } from '../B4ACodeTree/B4ATreeActions';
 
-const pageSize = 4000;
+// const pageSize = 4000;
 export default class B4ACloudCodeView extends React.Component {
   constructor(props){
     super(props);

--- a/src/components/CodeEditor/B4aCodeEditor.react.js
+++ b/src/components/CodeEditor/B4aCodeEditor.react.js
@@ -9,7 +9,7 @@ import { linter, lintGutter } from '@codemirror/lint';
 import globals from 'globals';
 import { createTheme } from '@uiw/codemirror-themes';
 import { tags as t } from '@lezer/highlight';
-import * as eslint from 'eslint-linter-browserify';
+// import * as eslint from 'eslint-linter-browserify';
 // import { StreamLanguage } from '@codemirror/language';
 
 const myTheme = createTheme({
@@ -61,8 +61,37 @@ const config = {
   }
 };
 
+const loadEslint = () => {
+  return new Promise((resolve, reject) => {
+    if (window.eslint) {
+      resolve(window.eslint);
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/eslint-linter-browserify/linter.min.js';
+    script.async = true;
+    script.onload = () => resolve(window.eslint);
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+};
+
 const B4aCodeEditor = forwardRef(({ code: initialCode, onCodeChange, mode }, ref) => {
   const [code, setCode] = useState(initialCode);
+  const [eslintInstance, setEslintInstance] = useState(null);
+
+  useEffect(() => {
+    if (mode === 'javascript' || mode === 'js') {
+      loadEslint()
+        .then(eslint => {
+          setEslintInstance(new eslint.Linter());
+        })
+        .catch(error => {
+          console.error('Failed to load ESLint:', error);
+        });
+    }
+  }, [mode]);
 
   useEffect(() => {
     if (window && window.document.querySelector('.cm-theme')) {
@@ -94,8 +123,10 @@ const B4aCodeEditor = forwardRef(({ code: initialCode, onCodeChange, mode }, ref
         return [json()];
       case 'javascript':
       case 'js':
-        return [javascript(),
-          linter(esLint(new eslint.Linter(), config))];
+        return [
+          javascript(),
+          ...(eslintInstance ? [linter(esLint(eslintInstance, config))] : [])
+        ];
       default:
         return [];
     }

--- a/src/components/PermissionsCollaboratorDialog/PermissionsCollaboratorDialog.react.js
+++ b/src/components/PermissionsCollaboratorDialog/PermissionsCollaboratorDialog.react.js
@@ -17,8 +17,8 @@ import Field from '../Field/Field.react'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import 'components/PermissionsCollaboratorDialog/Tabs.css'
 import B4aToggle from 'components/Toggle/B4aToggle.react';
-import lodash from 'lodash'
 
+import { isEqual, mapValues } from 'lib/lodash';
 
 const origin = new Position(0, 0);
 
@@ -93,7 +93,7 @@ export default class PermissionsCollaboratorDialog extends React.Component {
   }) {
     super();
 
-    const isDefaultFeatures = lodash.isEqual(customFeaturesPermissions, defaultFeaturesPermissions);
+    const isDefaultFeatures = isEqual(customFeaturesPermissions, defaultFeaturesPermissions);
     const selectedClassesTab = customFeaturesPermissions === undefined || !customFeaturesPermissions['classes'] ? 'Write' : (customFeaturesPermissions['classes'] === 'Custom' ? 'CustomClasses' :  customFeaturesPermissions['classes'])
 
     this.state = {
@@ -305,10 +305,10 @@ export default class PermissionsCollaboratorDialog extends React.Component {
                   }
                   // Set classes permissions
                   if (this.state.selectedClassesTab === 'CustomClasses') {
-                    classesPermissions = Object.assign(this.state.classesPermissions)
+                    classesPermissions = Object.assign({}, this.state.classesPermissions)
                     featuresPermissions['classes'] = 'Custom'
                   } else {
-                    classesPermissions = lodash.mapValues(this.state.classesPermissions, () => this.state.selectedClassesTab)
+                    classesPermissions = mapValues(this.state.classesPermissions, () => this.state.selectedClassesTab)
                     featuresPermissions['classes'] = this.state.selectedClassesTab
                   }
                   this.props.onConfirm(featuresPermissions, classesPermissions)

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -18,7 +18,7 @@ import Config from './Data/Config/Config.react';
 import FourOhFour from 'components/FourOhFour/FourOhFour.react';
 import GeneralSettings from './Settings/GeneralSettings.react';
 import GraphQLConsole from './Data/ApiConsole/GraphQLConsole.react';
-import HostingSettings from './Settings/HostingSettings.react';
+// import HostingSettings from './Settings/HostingSettings.react';
 import HubConnections from './Hub/HubConnections.react';
 import IndexManager from './IndexManager/IndexManager.react'
 import JobEdit from 'dashboard/Data/Jobs/JobEdit.react';
@@ -42,25 +42,25 @@ import moment from 'moment';
 import B4aConnectPage from './B4aConnectPage/B4aConnectPage.react';
 import AccountView from './AccountView.react';
 
-import Migration from './Data/Migration/Migration.react';
+// import Migration from './Data/Migration/Migration.react';
 import ParseApp from 'lib/ParseApp';
 import PushAudiencesIndex from './Push/PushAudiencesIndex.react';
 import PushDetails from './Push/PushDetails.react';
 import PushIndex from './Push/PushIndex.react';
 import PushNew from './Push/PushNew.react';
-import PushSettings from './Settings/PushSettings.react';
+// import PushSettings from './Settings/PushSettings.react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import RestConsole from './Data/ApiConsole/RestConsole.react';
-import SchemaOverview from './Data/Browser/SchemaOverview.react';
+// import SchemaOverview from './Data/Browser/SchemaOverview.react';
 import SecuritySettings from './Settings/SecuritySettings.react';
 import SettingsData from './Settings/SettingsData.react';
 import SlowQueries from './Analytics/SlowQueries/SlowQueries.react';
 import styles from 'dashboard/Apps/AppsIndex.scss';
-import UsersSettings from './Settings/UsersSettings.react';
+// import UsersSettings from './Settings/UsersSettings.react';
 import Webhooks from './Data/Webhooks/Webhooks.react';
 import baseStyles from 'stylesheets/base.scss';
 import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate, Link } from 'react-router-dom';
-import Security from './Settings/Security/Security.react';
+// import Security from './Settings/Security/Security.react';
 import { Navbar } from '@back4app2/react-components';
 import back4app2 from '../lib/back4app2';
 import { initializeAmplitude } from 'lib/amplitudeEvents';
@@ -68,17 +68,17 @@ import { setUser as setSentryUser } from '@sentry/react';
 
 const ShowSchemaOverview = false; //In progress features. Change false to true to work on this feature.
 
-class Empty extends React.Component {
-  render() {
-    return <div>Not yet implemented</div>;
-  }
-}
+// class Empty extends React.Component {
+//   render() {
+//     return <div>Not yet implemented</div>;
+//   }
+// }
 
-const AccountSettingsPage = () => (
-  <AccountView section="Account Settings">
-    <AccountOverview />
-  </AccountView>
-);
+// const AccountSettingsPage = () => (
+//   <AccountView section="Account Settings">
+//     <AccountOverview />
+//   </AccountView>
+// );
 
 async function fetchHubUser() {
   try {
@@ -332,12 +332,12 @@ class Dashboard extends React.Component {
     const SettingsRoute = (
       <Route element={<SettingsData />}>
         {/* <Route path='dashboard' element={<DashboardSettings />} /> */}
-        <Route path='security' element={<Security />} />
+        {/* <Route path='security' element={<Security />} /> */}
         <Route path='general' element={<GeneralSettings />} />
         <Route path='keys' element={<SecuritySettings />} />
-        <Route path='users' element={<UsersSettings />} />
+        {/* <Route path='users' element={<UsersSettings />} />
         <Route path='push' element={<PushSettings />} />
-        <Route path='hosting' element={<HostingSettings />} />
+        <Route path='hosting' element={<HostingSettings />} /> */}
         <Route index element={<Navigate replace to='general' />} />
       </Route>
     );
@@ -375,7 +375,8 @@ class Dashboard extends React.Component {
       </Route>
     );
 
-    const BrowserRoute = ShowSchemaOverview ? SchemaOverview : Browser;
+    // const BrowserRoute = ShowSchemaOverview ? SchemaOverview : Browser;
+    const BrowserRoute = Browser;
 
     const ApiConsoleRoute = (
       <Route element={<ApiConsole />}>
@@ -390,7 +391,7 @@ class Dashboard extends React.Component {
       <Route element={<AppData />}>
         <Route index element={<Navigate replace to="overview" />} />
 
-        <Route path="getting_started" element={<Empty />} />
+        {/* <Route path="getting_started" element={<Empty />} /> */}
         <Route path="overview" element={<AppOverview />} />
 
         <Route path="browser/:className/:entityId/:relationName" element={<BrowserRoute />} />
@@ -407,7 +408,7 @@ class Dashboard extends React.Component {
 
         <Route path="api_console">{ApiConsoleRoute}</Route>
 
-        <Route path="migration" element={<Migration />} />
+        {/* <Route path="migration" element={<Migration />} /> */}
 
         <Route path="push" element={<Navigate replace to="new" />} />
         <Route path="push/activity" element={<Navigate replace to="all" />} />
@@ -447,8 +448,8 @@ class Dashboard extends React.Component {
     return (
       <Routes>
         <Route path="/apps">{Index}</Route>
-        <Route path="account/overview" element={<AccountSettingsPage />} />
-        <Route path="account" element={<Navigate replace to="overview" />} />
+        {/* <Route path="account/overview" element={<AccountSettingsPage />} /> */}
+        {/* <Route path="account" element={<Navigate replace to="overview" />} /> */}
         <Route index element={<Navigate replace to="/apps" />} />
         <Route path="*" element={<FourOhFour />} />
       </Routes>

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -38,7 +38,7 @@ import ServerSettings from 'dashboard/ServerSettings/ServerSettings.react';
 import { Helmet } from 'react-helmet';
 import Playground from './Data/Playground/Playground.react';
 import axios from 'lib/axios';
-import moment from 'moment';
+// import moment from 'moment';
 import B4aConnectPage from './B4aConnectPage/B4aConnectPage.react';
 import AccountView from './AccountView.react';
 
@@ -126,12 +126,12 @@ const PARSE_DOT_COM_SERVER_INFO = {
   status: 'SUCCESS',
 }
 
-const monthQuarter = {
-  '0': 'Q1',
-  '1': 'Q2',
-  '2': 'Q3',
-  '3': 'Q4'
-};
+// const monthQuarter = {
+//   '0': 'Q1',
+//   '1': 'Q2',
+//   '2': 'Q3',
+//   '3': 'Q4'
+// };
 
 const waitForScriptToLoad = async conditionFn => {
   for (let i = 1; i <= 20; i++) {
@@ -163,20 +163,22 @@ class Dashboard extends React.Component {
     get('/parse-dashboard-config.json').then(({ apps, newFeaturesInLatestVersion = [], user }) => {
       fetchHubUser().then(userDetail => {
         user.createdAt = userDetail.createdAt;
-        const now = moment();
-        const hourDiff = now.diff(userDetail.createdAt, 'hours');
-        if(hourDiff === 0){
+        const now = new Date();
+        const createdAt = new Date(userDetail.createdAt);
+        const hourDiff = Math.floor((now - createdAt) / (1000 * 60 * 60));
+        if (hourDiff === 0) {
           return;
         }
         if (userDetail.disableSolucxForm) {
           return;
         }
         // Flow1 are users who signed up less than 30 days ago (720 hours)
-        const isFlow1 = hourDiff <= 720 ? true : false;
+        const isFlow1 = hourDiff <= 720;
         let transactionId = userDetail.id;
-        if(!isFlow1){
-          const quarter = monthQuarter[parseInt(now.month() / 3)];
-          transactionId += `${now.year()}${quarter}`;
+        if (!isFlow1) {
+          const monthQuarter = ['Q1', 'Q2', 'Q3', 'Q4'];
+          const quarter = monthQuarter[Math.floor(now.getMonth() / 3)];
+          transactionId += `${now.getFullYear()}${quarter}`;
         }
         const options = {
           transaction_id: transactionId,

--- a/src/dashboard/Data/AppOverview/AppOverview.scss
+++ b/src/dashboard/Data/AppOverview/AppOverview.scss
@@ -948,13 +948,18 @@
       pre {
         background: #111214 !important;
         border-radius: 4px;
-        padding: 1rem 1.5rem 1rem 0!important;
+        padding: 0rem 1.5rem 1.5rem 0!important;
         margin: 1rem 0;
         overflow-x: auto;
         margin: none !important;
         border-top-left-radius: 0 !important;
         border-top-right-radius: 0 !important;
         font-family: 'Roboto Mono', monospace !important;
+        padding-left: 3.5em !important;
+
+        pre.line-numbers:before {
+          background: transparent !important;
+        }
 
         code {
           font-family: 'Roboto Mono', monospace !important;

--- a/src/dashboard/Data/AppOverview/ConnectAppModal.react.js
+++ b/src/dashboard/Data/AppOverview/ConnectAppModal.react.js
@@ -1,14 +1,30 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Popover from 'components/Popover/Popover.react';
 import Position from 'lib/Position';
 import styles from 'dashboard/Data/AppOverview/AppOverview.scss';
 import Icon from 'components/Icon/Icon.react';
 import ReactMarkdown from 'react-markdown';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import Prism from 'prismjs';
+// Import Prism Line Numbers plugin
+import 'prismjs/plugins/line-numbers/prism-line-numbers';
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css';
+
+import 'prismjs/components/prism-markup-templating.js';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-graphql';
+import 'prismjs/components/prism-java';
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-dart';
+import 'prismjs/components/prism-kotlin';
+import 'prismjs/components/prism-swift';
+
+import 'prismjs/plugins/line-numbers/prism-line-numbers'
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
+
 // eslint-disable-next-line no-unused-vars
 import customPrisma from 'stylesheets/b4a-prisma.css';
-// import B4aTooltip from 'components/Tooltip/B4aTooltip.react';
+
 
 const LanguageDocMap = {
   rest: {
@@ -860,6 +876,12 @@ const origin = new Position(0, 0);
 const CodeBlock = ({ language, value }) => {
   const [copied, setCopied] = useState(false);
 
+  useEffect(() => {
+    if (typeof Prism !== 'undefined') {
+      Prism.highlightAll();
+    }
+  }, [value, language]);
+
   const copyToClipboard = async () => {
     try {
       await navigator.clipboard.writeText(value);
@@ -890,9 +912,9 @@ const CodeBlock = ({ language, value }) => {
           </button>
         </div>
       </div>
-      <SyntaxHighlighter language={language} style={oneDark} showLineNumbers={true}>
-        {value}
-      </SyntaxHighlighter>
+      <pre className="line-numbers">
+        <code className={`language-${language}`}>{value}</code>
+      </pre>
     </div>
   );
 };

--- a/src/dashboard/Data/Browser/B4ABrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/B4ABrowserToolbar.react.js
@@ -12,7 +12,7 @@ import styles from 'dashboard/Data/Browser/Browser.scss';
 import Toolbar from 'components/Toolbar/Toolbar.react';
 import Toggle from 'components/Toggle/Toggle.react';
 import Button from 'components/Button/Button.react'
-import VideoTutorialButton from 'components/VideoTutorialButton/VideoTutorialButton.react';
+// import VideoTutorialButton from 'components/VideoTutorialButton/VideoTutorialButton.react';
 import B4aColumnsConfiguration from 'components/ColumnsConfiguration/B4aColumnsConfiguration.react';
 import SubMenuItem from 'components/BrowserMenu/SubMenuItem.react';
 import { AmplitudeEvent, amplitudeLogEvent } from 'lib/amplitudeEvents';
@@ -291,13 +291,13 @@ const B4ABrowserToolbar = ({
     />
   }
   // TODO: Set the videoTutorialUrl
-  const videoTutorialUrl = 'https://youtu.be/0Ym9-BHI8Fg';
-  const helpsection = (
-    <span className="toolbar-help-section">
-      {/* {apiDocsButton} */}
-      <VideoTutorialButton url={videoTutorialUrl} additionalStyles={ { marginLeft: '8px', marginBottom: '4px' } } />
-    </span>
-  );
+  // const videoTutorialUrl = 'https://youtu.be/0Ym9-BHI8Fg';
+  // const helpsection = (
+  //   <span className="toolbar-help-section">
+  //     {/* {apiDocsButton} */}
+  //     <VideoTutorialButton url={videoTutorialUrl} additionalStyles={ { marginLeft: '8px', marginBottom: '4px' } } />
+  //   </span>
+  // );
 
   const clpDialogRef = useRef(null);
   const showCLP = () => {
@@ -316,7 +316,8 @@ const B4ABrowserToolbar = ({
       subsection="Browser"
       details={relation ? details.join(' \u2022 ') : details.join(' \u2022 ')}
       className={subsection}
-      helpsection={helpsection}>
+      // helpsection={helpsection}
+    >
       {onAddRow && (
         <a className={classes.join(' ')} onClick={onClick}>
           <Icon name='add-outline' width={14} height={14} />

--- a/src/dashboard/Settings/Collaborators.react.js
+++ b/src/dashboard/Settings/Collaborators.react.js
@@ -9,7 +9,7 @@ import FormTableCollab from 'components/FormTableCollab/FormTableCollab.react';
 import PermissionsCollaboratorDialog from 'components/PermissionsCollaboratorDialog/PermissionsCollaboratorDialog.react';
 import Swal from 'sweetalert2'
 
-import lodash from 'lodash'
+import { mapValues } from 'lib/lodash'
 import AccountManager from 'lib/AccountManager';
 import Field from 'components/Field/Field.react';
 import Fieldset from 'components/Fieldset/Fieldset.react';
@@ -98,7 +98,7 @@ export default class Collaborators extends React.Component {
   getDefaultClasses() {
     return this.context.classCounts &&
       this.context.classCounts.counts &&
-      lodash.mapValues(this.context.classCounts.counts, () => 'Write')
+      mapValues(this.context.classCounts.counts, () => 'Write')
   }
 
   handleAdd() {

--- a/src/lib/lodash.js
+++ b/src/lib/lodash.js
@@ -1,0 +1,45 @@
+// Function to check deep equality of two objects
+export const isEqual = (obj1, obj2) => {
+  if (obj1 === obj2) {
+    return true;
+  }
+
+  if (
+    typeof obj1 !== 'object' ||
+    obj1 === null ||
+    typeof obj2 !== 'object' ||
+    obj2 === null
+  ) {
+    return false;
+  }
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  for (const key of keys1) {
+    if (!keys2.includes(key)) {
+      return false;
+    }
+
+    if (!isEqual(obj1[key], obj2[key])) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+// Function to map values of an object
+export const mapValues = (obj, callback) => {
+  const result = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      result[key] = callback(obj[key], key, obj);
+    }
+  }
+  return result;
+};

--- a/src/stylesheets/b4a-prisma.css
+++ b/src/stylesheets/b4a-prisma.css
@@ -4,3 +4,454 @@
   border-right: 1px solid #cccccc47 !important;
   min-width: 2.5rem !important;
 }
+
+/**
+ * One Dark theme for prism.js
+ * Based on Atom's One Dark theme: https://github.com/atom/atom/tree/master/packages/one-dark-syntax
+ */
+
+/**
+ * One Dark colours (accurate as of commit 8ae45ca on 6 Sep 2018)
+ * From colors.less
+ * --mono-1: hsl(220, 14%, 71%);
+ * --mono-2: hsl(220, 9%, 55%);
+ * --mono-3: hsl(220, 10%, 40%);
+ * --hue-1: hsl(187, 47%, 55%);
+ * --hue-2: hsl(207, 82%, 66%);
+ * --hue-3: hsl(286, 60%, 67%);
+ * --hue-4: hsl(95, 38%, 62%);
+ * --hue-5: hsl(355, 65%, 65%);
+ * --hue-5-2: hsl(5, 48%, 51%);
+ * --hue-6: hsl(29, 54%, 61%);
+ * --hue-6-2: hsl(39, 67%, 69%);
+ * --syntax-fg: hsl(220, 14%, 71%);
+ * --syntax-bg: hsl(220, 13%, 18%);
+ * --syntax-gutter: hsl(220, 14%, 45%);
+ * --syntax-guide: hsla(220, 14%, 71%, 0.15);
+ * --syntax-accent: hsl(220, 100%, 66%);
+ * From syntax-variables.less
+ * --syntax-selection-color: hsl(220, 13%, 28%);
+ * --syntax-gutter-background-color-selected: hsl(220, 13%, 26%);
+ * --syntax-cursor-line: hsla(220, 100%, 80%, 0.04);
+ */
+
+ code[class*="language-"],
+ pre[class*="language-"] {
+   background: hsl(220, 13%, 18%);
+   color: hsl(220, 14%, 71%);
+   text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+   font-family: "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+   direction: ltr;
+   text-align: left;
+   white-space: pre;
+   word-spacing: normal;
+   word-break: normal;
+   line-height: 1.5;
+   -moz-tab-size: 2;
+   -o-tab-size: 2;
+   tab-size: 2;
+   -webkit-hyphens: none;
+   -moz-hyphens: none;
+   -ms-hyphens: none;
+   hyphens: none;
+ }
+ 
+ /* Selection */
+ code[class*="language-"]::-moz-selection,
+ code[class*="language-"] *::-moz-selection,
+ pre[class*="language-"] *::-moz-selection {
+   background: hsl(220, 13%, 28%);
+   color: inherit;
+   text-shadow: none;
+ }
+ 
+ code[class*="language-"]::selection,
+ code[class*="language-"] *::selection,
+ pre[class*="language-"] *::selection {
+   background: hsl(220, 13%, 28%);
+   color: inherit;
+   text-shadow: none;
+ }
+ 
+ /* Code blocks */
+ pre[class*="language-"] {
+   padding: 1em;
+   margin: 0.5em 0;
+   overflow: auto;
+   border-radius: 0.3em;
+ }
+ 
+ /* Inline code */
+ :not(pre) > code[class*="language-"] {
+   padding: 0.2em 0.3em;
+   border-radius: 0.3em;
+   white-space: normal;
+ }
+ 
+ /* Print */
+ @media print {
+   code[class*="language-"],
+   pre[class*="language-"] {
+     text-shadow: none;
+   }
+ }
+ 
+ .token.comment,
+ .token.prolog,
+ .token.cdata {
+   color: hsl(220, 10%, 40%);
+ }
+ 
+ .token.doctype,
+ .token.punctuation,
+ .token.entity {
+   color: hsl(220, 14%, 71%);
+ }
+ 
+ .token.attr-name,
+ .token.class-name,
+ .token.boolean,
+ .token.constant,
+ .token.number,
+ .token.atrule {
+   color: hsl(29, 54%, 61%);
+ }
+ 
+ .token.keyword {
+   color: hsl(286, 60%, 67%);
+ }
+ 
+ .token.property,
+ .token.tag,
+ .token.symbol,
+ .token.deleted,
+ .token.important {
+   color: hsl(355, 65%, 65%);
+ }
+ 
+ .token.selector,
+ .token.string,
+ .token.char,
+ .token.builtin,
+ .token.inserted,
+ .token.regex,
+ .token.attr-value,
+ .token.attr-value > .token.punctuation {
+   color: hsl(95, 38%, 62%);
+ }
+ 
+ .token.variable,
+ .token.operator,
+ .token.function {
+   color: hsl(207, 82%, 66%);
+ }
+ 
+ .token.url {
+   color: hsl(187, 47%, 55%);
+ }
+ 
+ /* HTML overrides */
+ .token.attr-value > .token.punctuation.attr-equals,
+ .token.special-attr > .token.attr-value > .token.value.css {
+   color: hsl(220, 14%, 71%);
+ }
+ 
+ /* CSS overrides */
+ .language-css .token.selector {
+   color: hsl(355, 65%, 65%);
+ }
+ 
+ .language-css .token.property {
+   color: hsl(220, 14%, 71%);
+ }
+ 
+ .language-css .token.function,
+ .language-css .token.url > .token.function {
+   color: hsl(187, 47%, 55%);
+ }
+ 
+ .language-css .token.url > .token.string.url {
+   color: hsl(95, 38%, 62%);
+ }
+ 
+ .language-css .token.important,
+ .language-css .token.atrule .token.rule {
+   color: hsl(286, 60%, 67%);
+ }
+ 
+ /* JS overrides */
+ .language-javascript .token.operator {
+   color: hsl(286, 60%, 67%);
+ }
+ 
+ .language-javascript .token.template-string > .token.interpolation > .token.interpolation-punctuation.punctuation {
+   color: hsl(5, 48%, 51%);
+ }
+ 
+ /* JSON overrides */
+ .language-json .token.operator {
+   color: hsl(220, 14%, 71%);
+ }
+ 
+ .language-json .token.null.keyword {
+   color: hsl(29, 54%, 61%);
+ }
+ 
+ /* MD overrides */
+ .language-markdown .token.url,
+ .language-markdown .token.url > .token.operator,
+ .language-markdown .token.url-reference.url > .token.string {
+   color: hsl(220, 14%, 71%);
+ }
+ 
+ .language-markdown .token.url > .token.content {
+   color: hsl(207, 82%, 66%);
+ }
+ 
+ .language-markdown .token.url > .token.url,
+ .language-markdown .token.url-reference.url {
+   color: hsl(187, 47%, 55%);
+ }
+ 
+ .language-markdown .token.blockquote.punctuation,
+ .language-markdown .token.hr.punctuation {
+   color: hsl(220, 10%, 40%);
+   font-style: italic;
+ }
+ 
+ .language-markdown .token.code-snippet {
+   color: hsl(95, 38%, 62%);
+ }
+ 
+ .language-markdown .token.bold .token.content {
+   color: hsl(29, 54%, 61%);
+ }
+ 
+ .language-markdown .token.italic .token.content {
+   color: hsl(286, 60%, 67%);
+ }
+ 
+ .language-markdown .token.strike .token.content,
+ .language-markdown .token.strike .token.punctuation,
+ .language-markdown .token.list.punctuation,
+ .language-markdown .token.title.important > .token.punctuation {
+   color: hsl(355, 65%, 65%);
+ }
+ 
+ /* General */
+ .token.bold {
+   font-weight: bold;
+ }
+ 
+ .token.comment,
+ .token.italic {
+   font-style: italic;
+ }
+ 
+ .token.entity {
+   cursor: help;
+ }
+ 
+ .token.namespace {
+   opacity: 0.8;
+ }
+ 
+ /* Plugin overrides */
+ /* Selectors should have higher specificity than those in the plugins' default stylesheets */
+ 
+ /* Show Invisibles plugin overrides */
+ .token.token.tab:not(:empty):before,
+ .token.token.cr:before,
+ .token.token.lf:before,
+ .token.token.space:before {
+   color: hsla(220, 14%, 71%, 0.15);
+   text-shadow: none;
+ }
+ 
+ /* Toolbar plugin overrides */
+ /* Space out all buttons and move them away from the right edge of the code block */
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item {
+   margin-right: 0.4em;
+ }
+ 
+ /* Styling the buttons */
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > button,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > a,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > span {
+   background: hsl(220, 13%, 26%);
+   color: hsl(220, 9%, 55%);
+   padding: 0.1em 0.4em;
+   border-radius: 0.3em;
+ }
+ 
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:hover,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:focus,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:hover,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:focus,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:hover,
+ div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:focus {
+   background: hsl(220, 13%, 28%);
+   color: hsl(220, 14%, 71%);
+ }
+ 
+ /* Line Highlight plugin overrides */
+ /* The highlighted line itself */
+ .line-highlight.line-highlight {
+   background: hsla(220, 100%, 80%, 0.04);
+ }
+ 
+ /* Default line numbers in Line Highlight plugin */
+ .line-highlight.line-highlight:before,
+ .line-highlight.line-highlight[data-end]:after {
+   background: hsl(220, 13%, 26%);
+   color: hsl(220, 14%, 71%);
+   padding: 0.1em 0.6em;
+   border-radius: 0.3em;
+   box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.2); /* same as Toolbar plugin default */
+ }
+ 
+ /* Hovering over a linkable line number (in the gutter area) */
+ /* Requires Line Numbers plugin as well */
+ pre[id].linkable-line-numbers.linkable-line-numbers span.line-numbers-rows > span:hover:before {
+   background-color: hsla(220, 100%, 80%, 0.04);
+ }
+ 
+ /* Line Numbers and Command Line plugins overrides */
+ /* Line separating gutter from coding area */
+ .line-numbers.line-numbers .line-numbers-rows,
+ .command-line .command-line-prompt {
+   border-right-color: hsla(220, 14%, 71%, 0.15);
+   padding-top: 0 !important;
+    width: 40px !important;
+ }
+
+ pre.line-numbers:before {
+  background: transparent !important;
+  height: calc(100% - 1.5rem) !important;
+ }
+ 
+ /* Stuff in the gutter */
+ .line-numbers .line-numbers-rows > span:before,
+ .command-line .command-line-prompt > span:before {
+   color: hsl(220, 14%, 45%);
+   line-height: 1.5;
+    font-size: 13px;
+    padding-right: 13px;
+ }
+ 
+ /* Match Braces plugin overrides */
+ /* Note: Outline colour is inherited from the braces */
+ .rainbow-braces .token.token.punctuation.brace-level-1,
+ .rainbow-braces .token.token.punctuation.brace-level-5,
+ .rainbow-braces .token.token.punctuation.brace-level-9 {
+   color: hsl(355, 65%, 65%);
+ }
+ 
+ .rainbow-braces .token.token.punctuation.brace-level-2,
+ .rainbow-braces .token.token.punctuation.brace-level-6,
+ .rainbow-braces .token.token.punctuation.brace-level-10 {
+   color: hsl(95, 38%, 62%);
+ }
+ 
+ .rainbow-braces .token.token.punctuation.brace-level-3,
+ .rainbow-braces .token.token.punctuation.brace-level-7,
+ .rainbow-braces .token.token.punctuation.brace-level-11 {
+   color: hsl(207, 82%, 66%);
+ }
+ 
+ .rainbow-braces .token.token.punctuation.brace-level-4,
+ .rainbow-braces .token.token.punctuation.brace-level-8,
+ .rainbow-braces .token.token.punctuation.brace-level-12 {
+   color: hsl(286, 60%, 67%);
+ }
+ 
+ /* Diff Highlight plugin overrides */
+ /* Taken from https://github.com/atom/github/blob/master/styles/variables.less */
+ pre.diff-highlight > code .token.token.deleted:not(.prefix),
+ pre > code.diff-highlight .token.token.deleted:not(.prefix) {
+   background-color: hsla(353, 100%, 66%, 0.15);
+ }
+ 
+ pre.diff-highlight > code .token.token.deleted:not(.prefix)::-moz-selection,
+ pre.diff-highlight > code .token.token.deleted:not(.prefix) *::-moz-selection,
+ pre > code.diff-highlight .token.token.deleted:not(.prefix)::-moz-selection,
+ pre > code.diff-highlight .token.token.deleted:not(.prefix) *::-moz-selection {
+   background-color: hsla(353, 95%, 66%, 0.25);
+ }
+ 
+ pre.diff-highlight > code .token.token.deleted:not(.prefix)::selection,
+ pre.diff-highlight > code .token.token.deleted:not(.prefix) *::selection,
+ pre > code.diff-highlight .token.token.deleted:not(.prefix)::selection,
+ pre > code.diff-highlight .token.token.deleted:not(.prefix) *::selection {
+   background-color: hsla(353, 95%, 66%, 0.25);
+ }
+ 
+ pre.diff-highlight > code .token.token.inserted:not(.prefix),
+ pre > code.diff-highlight .token.token.inserted:not(.prefix) {
+   background-color: hsla(137, 100%, 55%, 0.15);
+ }
+ 
+ pre.diff-highlight > code .token.token.inserted:not(.prefix)::-moz-selection,
+ pre.diff-highlight > code .token.token.inserted:not(.prefix) *::-moz-selection,
+ pre > code.diff-highlight .token.token.inserted:not(.prefix)::-moz-selection,
+ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::-moz-selection {
+   background-color: hsla(135, 73%, 55%, 0.25);
+ }
+ 
+ pre.diff-highlight > code .token.token.inserted:not(.prefix)::selection,
+ pre.diff-highlight > code .token.token.inserted:not(.prefix) *::selection,
+ pre > code.diff-highlight .token.token.inserted:not(.prefix)::selection,
+ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
+   background-color: hsla(135, 73%, 55%, 0.25);
+ }
+ 
+ /* Previewers plugin overrides */
+ /* Based on https://github.com/atom-community/atom-ide-datatip/blob/master/styles/atom-ide-datatips.less and https://github.com/atom/atom/blob/master/packages/one-dark-ui */
+ /* Border around popup */
+ .prism-previewer.prism-previewer:before,
+ .prism-previewer-gradient.prism-previewer-gradient div {
+   border-color: hsl(224, 13%, 17%);
+ }
+ 
+ /* Angle and time should remain as circles and are hence not included */
+ .prism-previewer-color.prism-previewer-color:before,
+ .prism-previewer-gradient.prism-previewer-gradient div,
+ .prism-previewer-easing.prism-previewer-easing:before {
+   border-radius: 0.3em;
+ }
+ 
+ /* Triangles pointing to the code */
+ .prism-previewer.prism-previewer:after {
+   border-top-color: hsl(224, 13%, 17%);
+ }
+ 
+ .prism-previewer-flipped.prism-previewer-flipped.after {
+   border-bottom-color: hsl(224, 13%, 17%);
+ }
+ 
+ /* Background colour within the popup */
+ .prism-previewer-angle.prism-previewer-angle:before,
+ .prism-previewer-time.prism-previewer-time:before,
+ .prism-previewer-easing.prism-previewer-easing {
+   background: hsl(219, 13%, 22%);
+ }
+ 
+ /* For angle, this is the positive area (eg. 90deg will display one quadrant in this colour) */
+ /* For time, this is the alternate colour */
+ .prism-previewer-angle.prism-previewer-angle circle,
+ .prism-previewer-time.prism-previewer-time circle {
+   stroke: hsl(220, 14%, 71%);
+   stroke-opacity: 1;
+ }
+ 
+ /* Stroke colours of the handle, direction point, and vector itself */
+ .prism-previewer-easing.prism-previewer-easing circle,
+ .prism-previewer-easing.prism-previewer-easing path,
+ .prism-previewer-easing.prism-previewer-easing line {
+   stroke: hsl(220, 14%, 71%);
+ }
+ 
+ /* Fill colour of the handle */
+ .prism-previewer-easing.prism-previewer-easing circle {
+   fill: transparent;
+ }

--- a/webpack/homolog.config.js
+++ b/webpack/homolog.config.js
@@ -1,41 +1,69 @@
-const configuration = require('./publish.config.js');
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+const configuration = require('./base.config.js');
 const webpack = require('webpack');
-const TerserPlugin = require('terser-webpack-plugin');
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
+configuration.mode = 'production';
+configuration.entry = {
+  dashboard: './dashboard/index.js',
+};
+
+configuration.output.path = path.resolve('./Parse-Dashboard/public/bundles');
+configuration.output.filename = '[name].[chunkhash].js';
+
+configuration.optimization = {
+  usedExports: true,
+  minimize: true,
+  concatenateModules: true,
+  sideEffects: true,
+  providedExports: true,
+  innerGraph: true,
+  splitChunks: {
+    chunks: 'all',
+    minSize: 20000,
+    maxAsyncRequests: 30,
+    maxInitialRequests: 30
+  }
+};
 
 configuration.plugins.push(
+  new HtmlWebpackPlugin({
+    template: '../Parse-Dashboard/index.ejs',
+    filename: path.resolve('./Parse-Dashboard/public/index.html')
+  }),
   new webpack.DefinePlugin({
     'process.env': {
       'NODE_ENV': JSON.stringify('homolog'),
       'SENTRY_ENV': JSON.stringify('homolog')
     }
   }),
-  new webpack.SourceMapDevToolPlugin({
-    filename: '[file].map',
-    include: /dashboard.*.*/
-  })
+  new BundleAnalyzerPlugin()
 );
 
-configuration.optimization = {
-  splitChunks: {
-    cacheGroups: {
-      commons: {
-        test: /[\\/]node_modules[\\/]/,
-        name: 'vendors',
-        chunks: 'all'
-      }
+configuration.module = configuration.module || {};
+configuration.module.rules = configuration.module.rules || [];
+
+// Ensure babel-loader is configured for tree shaking
+const babelRule = configuration.module.rules.find(rule => rule.use && rule.use.includes('babel-loader'));
+if (babelRule) {
+  babelRule.use = {
+    loader: 'babel-loader',
+    options: {
+      presets: [
+        ['@babel/preset-env', {
+          modules: false // This is important for tree shaking
+        }]
+      ]
     }
-  },
-  minimize: true,
-  minimizer: [
-    new TerserPlugin({
-      // cache: true,
-      parallel: true,
-      terserOptions: {
-        sourceMap: true,
-        mangle: false
-      }
-    })
-  ]
+  };
 }
 
 module.exports = configuration;

--- a/webpack/homolog.config.js
+++ b/webpack/homolog.config.js
@@ -1,69 +1,41 @@
-/*
- * Copyright (c) 2016-present, Parse, LLC
- * All rights reserved.
- *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
- */
-const configuration = require('./base.config.js');
+const configuration = require('./publish.config.js');
 const webpack = require('webpack');
-const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-
-configuration.mode = 'production';
-configuration.entry = {
-  dashboard: './dashboard/index.js',
-};
-
-configuration.output.path = path.resolve('./Parse-Dashboard/public/bundles');
-configuration.output.filename = '[name].[chunkhash].js';
-
-configuration.optimization = {
-  usedExports: true,
-  minimize: true,
-  concatenateModules: true,
-  sideEffects: true,
-  providedExports: true,
-  innerGraph: true,
-  splitChunks: {
-    chunks: 'all',
-    minSize: 20000,
-    maxAsyncRequests: 30,
-    maxInitialRequests: 30
-  }
-};
+const TerserPlugin = require('terser-webpack-plugin');
 
 configuration.plugins.push(
-  new HtmlWebpackPlugin({
-    template: '../Parse-Dashboard/index.ejs',
-    filename: path.resolve('./Parse-Dashboard/public/index.html')
-  }),
   new webpack.DefinePlugin({
     'process.env': {
       'NODE_ENV': JSON.stringify('homolog'),
       'SENTRY_ENV': JSON.stringify('homolog')
     }
   }),
-  // new BundleAnalyzerPlugin()
+  new webpack.SourceMapDevToolPlugin({
+    filename: '[file].map',
+    include: /dashboard.*.*/
+  })
 );
 
-configuration.module = configuration.module || {};
-configuration.module.rules = configuration.module.rules || [];
-
-// Ensure babel-loader is configured for tree shaking
-const babelRule = configuration.module.rules.find(rule => rule.use && rule.use.includes('babel-loader'));
-if (babelRule) {
-  babelRule.use = {
-    loader: 'babel-loader',
-    options: {
-      presets: [
-        ['@babel/preset-env', {
-          modules: false // This is important for tree shaking
-        }]
-      ]
+configuration.optimization = {
+  splitChunks: {
+    cacheGroups: {
+      commons: {
+        test: /[\\/]node_modules[\\/]/,
+        name: 'vendors',
+        chunks: 'all'
+      }
     }
-  };
+  },
+  minimize: true,
+  minimizer: [
+    new TerserPlugin({
+      // cache: true,
+      parallel: true,
+      terserOptions: {
+        sourceMap: true,
+        mangle: false
+      }
+    })
+  ]
 }
 
 module.exports = configuration;

--- a/webpack/homolog.config.js
+++ b/webpack/homolog.config.js
@@ -9,7 +9,7 @@ const configuration = require('./base.config.js');
 const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 configuration.mode = 'production';
 configuration.entry = {
@@ -45,7 +45,7 @@ configuration.plugins.push(
       'SENTRY_ENV': JSON.stringify('homolog')
     }
   }),
-  new BundleAnalyzerPlugin()
+  // new BundleAnalyzerPlugin()
 );
 
 configuration.module = configuration.module || {};

--- a/webpack/production.config.js
+++ b/webpack/production.config.js
@@ -19,7 +19,18 @@ configuration.output.path = path.resolve('./Parse-Dashboard/public/bundles');
 configuration.output.filename = '[name].[chunkhash].js';
 
 configuration.optimization = {
+  usedExports: true,
   minimize: true,
+  concatenateModules: true,
+  sideEffects: true,
+  providedExports: true,
+  innerGraph: true,
+  splitChunks: {
+    chunks: 'all',
+    minSize: 20000,
+    maxAsyncRequests: 30,
+    maxInitialRequests: 30
+  }
 };
 
 configuration.plugins.push(
@@ -34,5 +45,23 @@ configuration.plugins.push(
     }
   }),
 );
+
+configuration.module = configuration.module || {};
+configuration.module.rules = configuration.module.rules || [];
+
+// Ensure babel-loader is configured for tree shaking
+const babelRule = configuration.module.rules.find(rule => rule.use && rule.use.includes('babel-loader'));
+if (babelRule) {
+  babelRule.use = {
+    loader: 'babel-loader',
+    options: {
+      presets: [
+        ['@babel/preset-env', {
+          modules: false // This is important for tree shaking
+        }]
+      ]
+    }
+  };
+}
 
 module.exports = configuration;


### PR DESCRIPTION
- Started with 7.62MB
- Implemented code splitting -> 7.4MB
- Removed unused routes from dashboard - 7.34MB
- Remove eslint-linter-browersify - 6.14MB
- Remove moment.js - 5.85MB
- Removed base64-async -> didn’t see any reference in the code - 5.85MB
- Remove references of react-player as it is not being used - 5.75MB
- Replaced react-syntax-highlighter with prisms -> 5.04MB 
- Removed lodash being used in Settings page -> 4.98MB



Affected pages - 
- cloud code editor for js files -> verify whether linter is working properly or not
- logic to show sloucx form
- app overview page connect button modal popup code snippets
- app settings -> collaborators
- 